### PR TITLE
feat: extract shared PostForm component from edit and new post forms

### DIFF
--- a/client/src/components/posts/NewPostForm.tsx
+++ b/client/src/components/posts/NewPostForm.tsx
@@ -1,18 +1,12 @@
-import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { createPost } from '../../services/postService'
-import { PostForm } from './Post.model'
+import { PostFormFields } from './Post.model'
+import PostForm from './PostForm'
 
 const NewPostForm: React.FC = () => {
-  const [title, setTitle] = useState<string>('')
-  const [body, setBody] = useState<string>('')
   const navigate = useNavigate()
 
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>): Promise<void> => {
-    e.preventDefault()
-
-    const post: PostForm = { title, body }
-
+  const handleSubmit = async (post: PostFormFields): Promise<void> => {
     try {
       const response = await createPost(post)
       navigate(`/posts/${response.id}`)
@@ -22,33 +16,11 @@ const NewPostForm: React.FC = () => {
   }
 
   return (
-    <div>
-      <h2>Create a New Post</h2>
-      <form onSubmit={handleSubmit}>
-        <div>
-          <label htmlFor='title'>Title:</label>
-          <input
-            required
-            type='text'
-            value={title}
-            id='title'
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setTitle(e.target.value)}
-          />
-        </div>
-        <div>
-          <label htmlFor='body'>Body:</label>
-          <textarea
-            required
-            value={body}
-            id='body'
-            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setBody(e.target.value)}
-          />
-        </div>
-        <div>
-          <button type='submit'>Save</button>
-        </div>
-      </form>
-    </div>
+    <PostForm
+      headerText="Create a New Post"
+      onSubmit={handleSubmit}
+      submitButtonText="Save"
+    />
   )
 }
 

--- a/client/src/components/posts/Post.model.ts
+++ b/client/src/components/posts/Post.model.ts
@@ -4,7 +4,7 @@ export interface Post {
   body: string
 }
 
-export interface PostForm {
+export interface PostFormFields {
   title: string
   body: string
 }

--- a/client/src/components/posts/PostEditForm.tsx
+++ b/client/src/components/posts/PostEditForm.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from "react"
-import { useNavigate, useParams } from "react-router-dom"
-import { fetchPost, updatePost } from "../../services/postService"
-import { Post } from "./Post.model"
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { fetchPost, updatePost } from '../../services/postService'
+import { Post, PostFormFields } from './Post.model'
+import PostForm from './PostForm'
 
 interface RouteParams extends Record<string, string> {
   id: string
@@ -24,14 +25,7 @@ const PostEditForm: React.FC = () => {
     fetchCurrentPost()
   }, [id])
 
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>): Promise<void> => {
-    e.preventDefault()
-
-    const updatedPost = {
-      title: post!.title,
-      body: post!.body,
-    }
-
+  const handleSubmit = async (updatedPost: PostFormFields): Promise<void> => {
     try {
       await updatePost(id as string, updatedPost)
       navigate(`/posts/${id}`)
@@ -43,35 +37,12 @@ const PostEditForm: React.FC = () => {
   if (!post) return <h2>Loading...</h2>
 
   return (
-    <div>
-      <h2>Edit Post</h2>
-      <form onSubmit={handleSubmit}>
-        <div>
-          <label htmlFor='title'>Title</label>
-          <br />
-          <input
-            required
-            id='title'
-            type='text'
-            value={post.title}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPost({ ...post, title: e.target.value })}
-          />
-        </div>
-        <div>
-          <label htmlFor='body'>Body</label>
-          <br />
-          <textarea
-            required
-            id='body'
-            value={post.body}
-            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setPost({ ...post, body: e.target.value })}
-          />
-        </div>
-        <div>
-          <button type='submit'>Save</button>
-        </div>
-      </form>
-    </div>
+    <PostForm
+      headerText="Edit Post"
+      onSubmit={handleSubmit}
+      submitButtonText="Save"
+      post={{ title: post.title, body: post.body }}
+    />
   )
 }
 

--- a/client/src/components/posts/PostForm.tsx
+++ b/client/src/components/posts/PostForm.tsx
@@ -34,7 +34,7 @@ function PostForm({
       <h2>{headerText}</h2>
       <form onSubmit={handleSubmit}>
         <div>
-          <label htmlFor="title">Title:</label>
+          <label htmlFor="title">Title</label>
           <input
             required
             type="text"

--- a/client/src/components/posts/PostForm.tsx
+++ b/client/src/components/posts/PostForm.tsx
@@ -44,7 +44,7 @@ function PostForm({
           />
         </div>
         <div>
-          <label htmlFor="body">Body:</label>
+          <label htmlFor="body">Body</label>
           <textarea
             required
             value={formData.body}

--- a/client/src/components/posts/PostForm.tsx
+++ b/client/src/components/posts/PostForm.tsx
@@ -1,0 +1,63 @@
+import { useState } from 'react'
+import { PostFormFields } from './Post.model'
+
+interface PostFormProps {
+  post?: PostFormFields
+  headerText: string
+  onSubmit: (post: PostFormFields) => void
+  submitButtonText: string
+}
+
+function PostForm({
+  post,
+  headerText,
+  onSubmit,
+  submitButtonText,
+}: PostFormProps) {
+  const [formData, setFormData] = useState<PostFormFields>(post || { title: '', body: '' })
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    onSubmit(formData)
+  }
+
+  const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFormData({ ...formData, title: e.target.value })
+  }
+
+  const handleBodyChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setFormData({ ...formData, body: e.target.value })
+  }
+
+  return (
+    <div>
+      <h2>{headerText}</h2>
+      <form onSubmit={handleSubmit}>
+        <div>
+          <label htmlFor="title">Title:</label>
+          <input
+            required
+            type="text"
+            value={formData.title}
+            id="title"
+            onChange={handleTitleChange}
+          />
+        </div>
+        <div>
+          <label htmlFor="body">Body:</label>
+          <textarea
+            required
+            value={formData.body}
+            id="body"
+            onChange={handleBodyChange}
+          />
+        </div>
+        <div>
+          <button type="submit">{submitButtonText}</button>
+        </div>
+      </form>
+    </div>
+  )
+}
+
+export default PostForm

--- a/client/src/test/components/posts/PostEditForm.test.tsx
+++ b/client/src/test/components/posts/PostEditForm.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import * as postService from '../../../services/postService'
 import PostEditForm from '../../../components/posts/PostEditForm'
-import { Post, PostForm } from '../../../components/posts/Post.model'
+import { Post, PostFormFields } from '../../../components/posts/Post.model'
 import { act } from 'react'
 
 jest.mock('../../../constants', () => ({
@@ -58,7 +58,7 @@ describe('PostEditForm', () => {
       expect(postService.fetchPost).toHaveBeenCalledTimes(1)
     })
 
-    const newPost: PostForm = {
+    const newPost: PostFormFields = {
       title: 'New Post Title',
       body: 'New Post Body',
     }


### PR DESCRIPTION
- Create reusable PostForm component with configurable props
- Refactor PostEditForm to use shared PostForm component
- Refactor NewPostForm to use shared PostForm component
- Update Post.model.ts to support form field types
- Update PostEditForm tests to work with new component structure
- Reduce code duplication and improve maintainability